### PR TITLE
Fix PHP 8.4 issue

### DIFF
--- a/src/Model/UsedModules.php
+++ b/src/Model/UsedModules.php
@@ -18,7 +18,7 @@ class UsedModules
         private readonly Config $config
     ) {}
 
-    public function collect(string $module, string $templateName= null): void
+    public function collect(string $module, ?string $templateName = null): void
     {
         $this->modules[$module] ??= [];
         $this->modules[$module][] =  $templateName;


### PR DESCRIPTION
Under PHP 8.4, the line gives a warning `Implicitly marking parameter $templateName as nullable is deprecated`.